### PR TITLE
fix: update translation for PWr to WrocławTech

### DIFF
--- a/app/controllers/translations_controller.ts
+++ b/app/controllers/translations_controller.ts
@@ -212,7 +212,7 @@ export default class TranslationsController {
         ? `
     Preferred translations for Polish to English:
      - "Koło naukowe" -> "Science Club"
-     - "PWr" -> "WUST"
+     - "PWr" -> "WrocławTech"
      - "Samorząd studentów" (or similar) -> "Student Council"
 
 


### PR DESCRIPTION
@simon-the-shark may i launch the nukes? 
```sql
DELETE
FROM translations
WHERE original_text ILIKE '%WUST%'
   OR translated_text ILIKE '%WUST%';
```

<img width="464" height="161" alt="image" src="https://github.com/user-attachments/assets/46077afe-786a-4db2-a857-7913d866630c" />